### PR TITLE
add button for downloading data on the homepage

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -11,6 +11,7 @@
         <NuxtLink :to="`/`" class="hover:text-blue-400">HOME</NuxtLink>
         <NuxtLink :to="`/about`" class="hover:text-blue-400">ABOUT</NuxtLink>
         <NuxtLink :to="`/examples`" class="hover:text-blue-400" >EXAMPLES</NuxtLink>
+        <a href="https://zenodo.org/record/5645154" class="hover:text-blue-400" >DOWNLOAD DATA</a>
       </div>
     </div>
     <Nuxt class="m-4 h-full" />


### PR DESCRIPTION
Add "download data" button on the homepage for the user to navigate to the zenodo page (containing the published data) directly.