### PR TITLE
Change IPSL to ICTP for REA method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ see the [Atlas about page](https://eucp-project.github.io/atlas/about).
 
 ## Citation
 
-To cite this repository, use the information avialable at [CITATION.cff](CITATION.cff),
+To cite this repository, use the information available at [CITATION.cff](CITATION.cff),
 and to cite the content of the Atlas, see the [Atlas about page](https://eucp-project.github.io/atlas/about).
 
 ## License
@@ -32,7 +32,7 @@ best to help you.
 
 ## Contributions
 
-For information on how to contribute to this atlas, please check the
+For information on how to contribute to this Atlas, please check the
 [contributing guidelines](CONTRIBUTING.md).
 
 ## Acknowledgements

--- a/python/README.md
+++ b/python/README.md
@@ -26,7 +26,7 @@ per each `institute`-`method`:
 - [Preprocess CNRM-KCC data](cleanup_CNRM_KCC_atlas_netcdf.ipynb)
 - [Preprocess EdinU-ASK data](cleanup_EdinU_ASK_atlas_netcdf.ipynb)
 - [Preprocess ETHZ-ClimWIP data](cleanup_ETHZ_ClimWIP_atlas_netcdf.ipynb)
-- [Preprocess IPSL-REA data](cleanup_IPSL_REA_atlas_netcdf.ipynb)
+- [Preprocess ICTP-REA data](cleanup_ICTP_REA_atlas_netcdf.ipynb)
 - [Preprocess UKMO-UKCP data](cleanup_UKMO_UKCP_atlas_netcdf.ipynb)
 - [Preprocess UoR-CALL data](cleanup_UoR_CALL_atlas_netcdf.ipynb)
 

--- a/python/cleanup_ICTP_REA_atlas_netcdf.ipynb
+++ b/python/cleanup_ICTP_REA_atlas_netcdf.ipynb
@@ -41,10 +41,10 @@
    "outputs": [],
    "source": [
     "# please specify data path\n",
-    "datapath = Path(\"/home/sarah/GitHub/atlas/AtlasData/raw\")\n",
+    "datapath = Path(\"./AtlasData/raw\")\n",
     "\n",
     "# please specify output path\n",
-    "output_path = Path(\"/home/sarah/GitHub/atlas/AtlasData/preprocess\")\n",
+    "output_path = Path(\"./AtlasData/preprocess\")\n",
     "os.makedirs(output_path, exist_ok=True)"
    ]
   },

--- a/python/cleanup_ICTP_REA_atlas_netcdf.ipynb
+++ b/python/cleanup_ICTP_REA_atlas_netcdf.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Cleaning up Atlas data - IPSL REA\n",
+    "## Cleaning up Atlas data - ICTP REA\n",
     "**Function**      : Preprocess netCDF files and restructure the dataset<br>\n",
     "**Description**   : In this notebook serves to clean up Atlas data which is given in netcdf format and aggregate the data into a single file.<br>\n",
     "**Return Values   : .nc files**<br>\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,15 +36,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "# please specify data path\n",
-    "datapath = Path(\"./AtlasData/raw\")\n",
+    "datapath = Path(\"/home/sarah/GitHub/atlas/AtlasData/raw\")\n",
     "\n",
     "# please specify output path\n",
-    "output_path = Path(\"./AtlasData/preprocess\")\n",
+    "output_path = Path(\"/home/sarah/GitHub/atlas/AtlasData/preprocess\")\n",
     "os.makedirs(output_path, exist_ok=True)"
    ]
   },
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
@@ -66,7 +66,7 @@
     "output_file_name = {\n",
     "    \"prefix\": \"atlas\",\n",
     "    \"activity\": \"EUCP\",  # project name e.g. EUCP\n",
-    "    \"institution_id\": \"IPSL\",  # IPSL\n",
+    "    \"institution_id\": \"ICTP\",  # ICTP\n",
     "    \"source\": \"CORDEX\",  # e.g. CMIP5, CMIP6 or CORDEX\n",
     "    \"method\": \"REA\",  # e.g. REA\n",
     "    \"sub_method\": \"cons\",  # e.g. cons or uncons\n",
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -222,13 +222,13 @@
        "     _CoordinateAxisType:  Lon}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ipsl_rea_ds = {}\n",
+    "ictp_rea_ds = {}\n",
     "for source in [\"CMIP5\", \"CMIP6\", \"CORDEX\"]:\n",
     "    seasons = []\n",
     "    for season in [\"DJF\", \"JJA\"]:\n",
@@ -236,8 +236,8 @@
     "        pr = load_data(source, season, \"pr\")\n",
     "        ds = xr.merge([tas, pr]).assign_coords(season=season)\n",
     "        seasons.append(ds)\n",
-    "    ipsl_rea_ds[source] = xr.concat(seasons, dim=\"season\")\n",
-    "ipsl_rea_ds"
+    "    ictp_rea_ds[source] = xr.concat(seasons, dim=\"season\")\n",
+    "ictp_rea_ds"
    ]
   },
   {
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,25 +386,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP5_REA_uncons_tas.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP5_REA_cons_tas.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP5_REA_uncons_pr.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP5_REA_cons_pr.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP6_REA_uncons_tas.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP6_REA_cons_tas.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP6_REA_uncons_pr.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CMIP6_REA_cons_pr.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CORDEX_REA_uncons_tas.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CORDEX_REA_cons_tas.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CORDEX_REA_uncons_pr.nc\n",
-      "one dataset is saved to atlas_EUCP_IPSL_CORDEX_REA_cons_pr.nc\n"
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP5_REA_uncons_tas.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP5_REA_cons_tas.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP5_REA_uncons_pr.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP5_REA_cons_pr.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP6_REA_uncons_tas.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP6_REA_cons_tas.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP6_REA_uncons_pr.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CMIP6_REA_cons_pr.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CORDEX_REA_uncons_tas.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CORDEX_REA_cons_tas.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CORDEX_REA_uncons_pr.nc\n",
+      "one dataset is saved to atlas_EUCP_ICTP_CORDEX_REA_cons_pr.nc\n"
      ]
     }
    ],
@@ -415,7 +415,7 @@
     "        output_file_name[\"cmor_var\"] = VAR_NAME\n",
     "        for i, sub_method in enumerate([\"uncons\", \"cons\"]):\n",
     "            output_file_name[\"sub_method\"] = sub_method\n",
-    "            new_ds = assembly(source, ipsl_rea_ds[source], VAR_NAME, i)\n",
+    "            new_ds = assembly(source, ictp_rea_ds[source], VAR_NAME, i)\n",
     "\n",
     "            # Fix attributes\n",
     "            for key in new_ds.keys():\n",
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -811,11 +811,11 @@
        "Data variables:\n",
        "    tas                 (time, y, x, percentile) float64 ...\n",
        "Attributes:\n",
-       "    description:  Contains modified IPSL REA data used for Atlas in EUCP proj...\n",
-       "    history:      original IPSL REA data fileseur_CORDEX_tas_2041-2060_vs_199...</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-ebdd7650-d0a2-44f1-8d4e-abc31f857918' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-ebdd7650-d0a2-44f1-8d4e-abc31f857918' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 2</li><li><span>y</span>: 412</li><li><span>x</span>: 424</li><li><span class='xr-has-index'>percentile</span>: 5</li><li><span class='xr-has-index'>climatology_bounds</span>: 4</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-c46fde8e-fd33-484e-8016-fecaade00b8e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c46fde8e-fd33-484e-8016-fecaade00b8e' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>climatology_bounds</span></div><div class='xr-var-dims'>(climatology_bounds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2050-06-01 ... 2051-03-01</div><input id='attrs-7022cac8-fce1-4228-b14d-1559e91c1248' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7022cac8-fce1-4228-b14d-1559e91c1248' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-146be0a8-da67-4646-b3c9-b103f144a7b7' class='xr-var-data-in' type='checkbox'><label for='data-146be0a8-da67-4646-b3c9-b103f144a7b7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2050-06-01T00:00:00.000000000&#x27;, &#x27;2050-09-01T00:00:00.000000000&#x27;,\n",
+       "    description:  Contains modified ICTP REA data used for Atlas in EUCP proj...\n",
+       "    history:      original ICTP REA data fileseur_CORDEX_tas_2041-2060_vs_199...</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-e3ecc4ad-85c6-4d99-815e-36e121677b80' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-e3ecc4ad-85c6-4d99-815e-36e121677b80' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 2</li><li><span>y</span>: 412</li><li><span>x</span>: 424</li><li><span class='xr-has-index'>percentile</span>: 5</li><li><span class='xr-has-index'>climatology_bounds</span>: 4</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-a26b03a7-dd15-4eb5-9029-3807c0a9afc5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a26b03a7-dd15-4eb5-9029-3807c0a9afc5' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>climatology_bounds</span></div><div class='xr-var-dims'>(climatology_bounds)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2050-06-01 ... 2051-03-01</div><input id='attrs-838469fb-418a-4352-9bd0-4de404885fd7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-838469fb-418a-4352-9bd0-4de404885fd7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d9c04ee5-42cf-4b78-aee8-2bd276954ea2' class='xr-var-data-in' type='checkbox'><label for='data-d9c04ee5-42cf-4b78-aee8-2bd276954ea2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2050-06-01T00:00:00.000000000&#x27;, &#x27;2050-09-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2050-12-01T00:00:00.000000000&#x27;, &#x27;2051-03-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2050-07-16 2051-01-16</div><input id='attrs-416a9739-4aff-4ccf-826d-d55f7d9cc495' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-416a9739-4aff-4ccf-826d-d55f7d9cc495' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-63c8337b-6ceb-4ccd-bf7e-c7233bbed399' class='xr-var-data-in' type='checkbox'><label for='data-63c8337b-6ceb-4ccd-bf7e-c7233bbed399' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2050-07-16T00:00:00.000000000&#x27;, &#x27;2051-01-16T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-000fb808-b7a8-4664-acda-b36237cff06b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-000fb808-b7a8-4664-acda-b36237cff06b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5293e53d-1445-4185-b1e6-d974e4eae259' class='xr-var-data-in' type='checkbox'><label for='data-5293e53d-1445-4185-b1e6-d974e4eae259' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[174688 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-311ab078-07bf-4978-b24a-3b1474cc1030' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-311ab078-07bf-4978-b24a-3b1474cc1030' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5ed4dad5-db64-4779-9399-6f51d61616db' class='xr-var-data-in' type='checkbox'><label for='data-5ed4dad5-db64-4779-9399-6f51d61616db' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[174688 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>percentile</span></div><div class='xr-var-dims'>(percentile)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>10 25 50 75 90</div><input id='attrs-d6ccb9a0-78bd-4fbd-97c9-851f850f0780' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d6ccb9a0-78bd-4fbd-97c9-851f850f0780' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-63a38769-59d9-463c-bea4-adbb4417b18e' class='xr-var-data-in' type='checkbox'><label for='data-63a38769-59d9-463c-bea4-adbb4417b18e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([10, 25, 50, 75, 90])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0c8ec794-99be-498b-822d-e4b0e34b015e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0c8ec794-99be-498b-822d-e4b0e34b015e' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, y, x, percentile)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-1736bde0-3461-4652-a3fc-9f436b449ccb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1736bde0-3461-4652-a3fc-9f436b449ccb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-37022160-ffa1-43b5-ab54-4cea0b2713b3' class='xr-var-data-in' type='checkbox'><label for='data-37022160-ffa1-43b5-ab54-4cea0b2713b3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Change in Air Temperature</dd><dt><span>standard_name :</span></dt><dd>Change in Air Temperature</dd><dt><span>long_name :</span></dt><dd>Change in Near-Surface Air Temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>cell_methods :</span></dt><dd>time: mean changes over 20 years 2041-2060 vs 1995-2014</dd></dl></div><div class='xr-var-data'><pre>[1746880 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a8ecfeb7-4062-4702-8925-dad3a01f0cd1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a8ecfeb7-4062-4702-8925-dad3a01f0cd1' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Contains modified IPSL REA data used for Atlas in EUCP project.</dd><dt><span>history :</span></dt><dd>original IPSL REA data fileseur_CORDEX_tas_2041-2060_vs_1995-2014_*_DJF.nc,eur_{project}_{var}_2041-2060_vs_1995-2014_*_JJA.nc</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2050-07-16 2051-01-16</div><input id='attrs-9b53a251-9312-4c9c-97c7-d288ae84965c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9b53a251-9312-4c9c-97c7-d288ae84965c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dd7577cb-4d6b-4200-8f7b-491c4288150c' class='xr-var-data-in' type='checkbox'><label for='data-dd7577cb-4d6b-4200-8f7b-491c4288150c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2050-07-16T00:00:00.000000000&#x27;, &#x27;2051-01-16T00:00:00.000000000&#x27;],\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-5f609299-ac71-4bbb-8efe-379a03cddb01' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5f609299-ac71-4bbb-8efe-379a03cddb01' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3460508d-858d-44e4-8c48-eb4a461c1ba7' class='xr-var-data-in' type='checkbox'><label for='data-3460508d-858d-44e4-8c48-eb4a461c1ba7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[174688 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-2e353a71-ca0b-4af9-98b7-71aa9d3174a2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2e353a71-ca0b-4af9-98b7-71aa9d3174a2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-079ac6bb-be65-420d-9dbe-549221effbf2' class='xr-var-data-in' type='checkbox'><label for='data-079ac6bb-be65-420d-9dbe-549221effbf2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[174688 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>percentile</span></div><div class='xr-var-dims'>(percentile)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>10 25 50 75 90</div><input id='attrs-98ec9ef2-2e9e-40b2-b292-17590550c5ae' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-98ec9ef2-2e9e-40b2-b292-17590550c5ae' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f6d10df1-9d8e-4b66-a729-51e10dc7afc2' class='xr-var-data-in' type='checkbox'><label for='data-f6d10df1-9d8e-4b66-a729-51e10dc7afc2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([10, 25, 50, 75, 90])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-39f71193-191e-4424-8432-797e6c28cc9d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-39f71193-191e-4424-8432-797e6c28cc9d' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tas</span></div><div class='xr-var-dims'>(time, y, x, percentile)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-0876a393-1847-4883-9436-57deec9997a9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0876a393-1847-4883-9436-57deec9997a9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c7ad4a4d-5e9f-4382-93b7-a2f18f09f738' class='xr-var-data-in' type='checkbox'><label for='data-c7ad4a4d-5e9f-4382-93b7-a2f18f09f738' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Change in Air Temperature</dd><dt><span>standard_name :</span></dt><dd>Change in Air Temperature</dd><dt><span>long_name :</span></dt><dd>Change in Near-Surface Air Temperature</dd><dt><span>units :</span></dt><dd>K</dd><dt><span>cell_methods :</span></dt><dd>time: mean changes over 20 years 2041-2060 vs 1995-2014</dd></dl></div><div class='xr-var-data'><pre>[1746880 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a81732c5-ac64-4316-b21c-81c85035a018' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a81732c5-ac64-4316-b21c-81c85035a018' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Contains modified ICTP REA data used for Atlas in EUCP project.</dd><dt><span>history :</span></dt><dd>original ICTP REA data fileseur_CORDEX_tas_2041-2060_vs_1995-2014_*_DJF.nc,eur_CORDEX_tas_2041-2060_vs_1995-2014_*_JJA.nc</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -830,17 +830,17 @@
        "Data variables:\n",
        "    tas                 (time, y, x, percentile) float64 ...\n",
        "Attributes:\n",
-       "    description:  Contains modified IPSL REA data used for Atlas in EUCP proj...\n",
-       "    history:      original IPSL REA data fileseur_CORDEX_tas_2041-2060_vs_199..."
+       "    description:  Contains modified ICTP REA data used for Atlas in EUCP proj...\n",
+       "    history:      original ICTP REA data fileseur_CORDEX_tas_2041-2060_vs_199..."
       ]
      },
-     "execution_count": 33,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ds = xr.open_dataset(output_path / \"atlas_EUCP_IPSL_CORDEX_REA_cons_tas.nc\")\n",
+    "ds = xr.open_dataset(output_path / \"atlas_EUCP_ICTP_CORDEX_REA_cons_tas.nc\")\n",
     "ds"
    ]
   },
@@ -871,7 +871,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The REA data (Zenodo publication) has “IPSL” in the filename of the REA data.   This data was produced by the International Centre for Theoretical Physics (ICTP) in Trieste, Italia – not IPSL.