### PR TITLE
update contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ candidate release, and amend the version tag with `rc` and the candidate number.
 
 ### Release on Zenodo
 
-Confirm the new release on [Zenodo]((FIXME). (TBD)
+Confirm the new release on [Zenodo](https://zenodo.org/record/5654741).
 
 ### Release on the Research Software Directory
 


### PR DESCRIPTION
The link to Zenodo was still TBD in the contribution guidelines. It has been updated with the existing record.