### PR TITLE
Add Zenodo information to citation info in About

### DIFF
--- a/content/questions/citing.md
+++ b/content/questions/citing.md
@@ -3,4 +3,6 @@ question: I'd like to cite the Atlas in my paper, how can I do this?
 sort: 7
 ---
 
-Great! The Atlas will have its own DOI. Citation information will follow soon.
+Great! You can cite the Atlas using its DOI: 10.5281/zenodo.5654741, and
+citation information on the [Zenodo
+repository](https://doi.org/10.5281/zenodo.5654741).

--- a/content/questions/citing.md
+++ b/content/questions/citing.md
@@ -6,3 +6,7 @@ sort: 7
 Great! You can cite the Atlas using its DOI: 10.5281/zenodo.5654741, and
 citation information on the [Zenodo
 repository](https://doi.org/10.5281/zenodo.5654741).
+
+If you want to cite a particular figure or piece of content shown in this Atlas,
+the information for its citation can be found under "Where can I find more
+information?".


### PR DESCRIPTION
The About page was still TBD on the Zenodo link. This has been added.